### PR TITLE
fix: delete useless 'COPY' line in front dockerfile

### DIFF
--- a/srcs/frontend/Dockerfile
+++ b/srcs/frontend/Dockerfile
@@ -1,5 +1,6 @@
 FROM nginx:alpine
 
+COPY ./src/ /
 COPY ./public/ /usr/share/nginx/html/
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 

--- a/srcs/frontend/Dockerfile
+++ b/srcs/frontend/Dockerfile
@@ -1,6 +1,5 @@
 FROM nginx:alpine
 
-COPY ./src/ /
 COPY ./public/ /usr/share/nginx/html/
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 

--- a/srcs/frontend/src/sample.js
+++ b/srcs/frontend/src/sample.js
@@ -1,0 +1,1 @@
+console.log("Hello!");


### PR DESCRIPTION
`frontend`의 `Dockerfile`에서 불필요해 보이는 라인을 확인했습니다. 삭제할까요?