### PR TITLE
feat: backend - add score and matches dummy data

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,9 +1,11 @@
 from django.urls import path, include
 
-from .views import LoginAPIView, LogoutAPIView, UserAPIView
+from .views import LoginAPIView, LogoutAPIView, UserAPIView, SocreAPIView, MatchesAPIView
 
 urlpatterns = [
     path('login', LoginAPIView.as_view()),
     path('logout', LogoutAPIView.as_view()),
     path('user/<str:intra_id>/', UserAPIView.as_view()),
+    path('phong/score/<str:intra_id>/', SocreAPIView.as_view()),
+    path('phong/matches/<int:match_id>/', MatchesAPIView.as_view()),
 ]

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -64,3 +64,102 @@ class UserAPIView(APIView):
         if 'message' in request_data:
             response_data['message'] = request_data['message']
         return Response(response_data, status=status.HTTP_200_OK)
+
+class SocreAPIView(APIView):
+    def get(self, request, intra_id):
+        game_type = request.query_params.get('game_type', None)
+        intra_id = request.query_params.get('intra_id', None)
+        page = int(request.query_params.get('page', 0))
+        page_size = int(request.query_params.get('page_size', 0))
+        
+        response_data = {
+            'page': page,
+            'page_size': page_size,
+            'last_page_index': 1,
+            'content_length': 2,
+            'data': [
+                {
+                    'match_id': 1,
+                    'game_type': 'phong_4',
+                    'score': [
+                        {
+                            'user': {'id': 0, 'intra_id': 'main_dummy', 'photo_id': 0}, 
+                            'value': 100
+                        },
+                        {
+                            'user': {'id': 0, 'intra_id': 'dummy1', 'photo_id': 0},
+                            'value': -60
+                        },
+                        {
+                            'user': {'id': 0, 'intra_id': 'dummy2', 'photo_id': 0},
+                            'value': -40
+                        },
+                        {
+                            'user': {'id': 0, 'intra_id': 'dummy3', 'photo_id': 0},
+                            'value': -20
+                        },
+                    ]
+                },
+                {
+                    'match_id': 2,
+                    'game_type': 'phong_4',
+                    'score': [
+                        {
+                            'user': {'id': 0, 'intra_id': 'main_dummy', 'photo_id': 0}, 
+                            'value': 100
+                        },
+                        {
+                            'user': {'id': 0, 'intra_id': 'dummy5', 'photo_id': 0},
+                            'value': -60
+                        },
+                        {
+                            'user': {'id': 0, 'intra_id': 'dummy6', 'photo_id': 0},
+                            'value': -40
+                        },
+                        {
+                            'user': {'id': 0, 'intra_id': 'dummy7', 'photo_id': 0},
+                            'value': -20
+                        },
+                    ]
+                }
+            ]
+        }
+        return Response(response_data, status=status.HTTP_200_OK)
+    
+class MatchesAPIView(APIView):
+    dummy = []
+    def __init__(self):
+        if not self.dummy:
+            for i in range(3):
+                self.dummy.append({
+                    "match_id": i,
+                    "game_type": "phong_4",
+                    "score": [
+                        {
+                            "user": { "id": 1, "intra_id": "main_dummy-" + str(i), "photo_id": 0 },
+                            "rating": 1024,
+                            "value": 100
+                        },
+                        {
+                            "user": { "id": 4, "intra_id": "dummy", "photo_id": 0 },
+                            "rating": 900,
+                            "value": -20
+                        },
+                        {
+                            "user": { "id": 3, "intra_id": "dummy", "photo_id": 0 },
+                            "rating": 1100,
+                            "value": -40
+                        },
+                        {
+                            "user": { "id": 2, "intra_id": "dummy", "photo_id": 0 },
+                            "rating": 1032,
+                            "value": -60
+                        },
+                    ],
+                })
+
+    def get(self, request, match_id):
+        response_data = next((item for item in self.dummy if item['match_id'] == match_id), None)
+        if not response_data:
+            return Response(response_data, status=status.HTTP_404_NOT_FOUND)
+        return Response(response_data, status=status.HTTP_200_OK)


### PR DESCRIPTION
추가적으로 요구가 되었던 dummy data들을 추가하였습니다.
- **`phong/score/<str:intra_id>/`**
  - `<intra_id>`의 전적을 볼 수 있는 API
- **`phong/matches/<int:match_id>/`**
  - 각 게임의 세부사항  `<int:match_id>`에 해당되는 게임 정보를 볼 수 있는 API