### PR TITLE
feat: use 42 oauth #33

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -30,6 +30,9 @@ DJANGO_SUPERUSER_EMAIL=admin@admin.com
 DJANGO_SUPERUSER_PASSWORD=admin
 SECRET_KEY=django-insecure-x3!8ygjvywgu87m%y4t_*-751j9d)^7h1#m$*e1uq+)b(8)wie
 
+# for oauth
+CLIENT_ID=u-s4t2ud-1c3b115249c3da127de46dd4e2de76774941f2e88b6c8a71b485ad540dad4810
+CLIENT_SECRET=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
 
 #Production Config
 GUNICORN_WORKERS=5

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -7,6 +7,13 @@ from .models import User, Profile
 class LoginSerializer(serializers.Serializer):
     code = serializers.CharField(max_length=100)
 
+class TokenSerializer(serializers.Serializer):
+    access_token = serializers.CharField(max_length=100)
+    token_type = serializers.CharField(max_length=100)
+    expires_in = serializers.IntegerField()
+    refresh_token = serializers.CharField(max_length=100)
+    created_at = serializers.IntegerField()
+
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -146,3 +146,10 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.BasicAuthentication',
     ],
 }
+
+# 42 OAuth
+# https://api.intra.42.fr/apidoc/guides/getting_started
+
+CLIENT_ID = os.environ.get('CLIENT_ID')
+CLIENT_SECRET = os.environ.get('CLIENT_SECRET')
+REDIRECT_URI = 'http://localhost:8000/api/login'


### PR DESCRIPTION
현재 백엔드에서만 테스트된 샘플 코드이므로 원하시는대로 수정하셔도 됩니다.

https의 수월한 적용을 위해 프론트/백엔드 통합한 코드는 분리하는게 좋을 것 같긴합니다.
- 프론트에서 GET frontend/login, GET frontend/callback을 구현
- 백엔드에서 POST backend/api/login으로 code를 전달하여 유저 정보 획득

# 연관 이슈
- #33 