### PR TITLE
fix: broadcast info for front

### DIFF
--- a/backend/game/Rule.py
+++ b/backend/game/Rule.py
@@ -18,7 +18,8 @@ class Rule:
     async def step(self, level, timer):
         print(level) # for debug
         await self.broadcast(self.players, {"type": "step", "level": level, "timer": timer})
-        await asyncio.sleep(timer)
+        if timer != 0:
+            await asyncio.sleep(timer)
 
     async def broadcast(self, players, json_data):
         for player in players:

--- a/backend/game/User.py
+++ b/backend/game/User.py
@@ -8,6 +8,7 @@ class User:
     def __init__(self, socket: WebSocketServerProtocol, intra_id, game_type):
         self.socket = socket
         self.intra_id = intra_id
+        self.photo_id = 0 # TODO: update photo_id
         self.game_type = game_type
         self.onclose: 'list[Coroutine]' = []
         self.onmessage: 'list[Coroutine]' = []

--- a/backend/game/pong/PongGame.py
+++ b/backend/game/pong/PongGame.py
@@ -94,6 +94,7 @@ class PongGame(Game):
         if self.onfinish is not None:
             await self.onfinish(self, [{
                 "intra_id": player.intra_id,
+                "photo_id": player.photo_id,
                 "score": player.data.score,
                 "hit": player.data.hit,
             } for player in self.players])

--- a/frontend/src/game/pong/PongGame.js
+++ b/frontend/src/game/pong/PongGame.js
@@ -15,6 +15,7 @@ export default class PongGame extends NetworkScene {
   static STATE_WAIT = 1;
   static STATE_PONG = 2;
   static STATE_PONG_TOURNAMENT = 3;
+  static STATE_END = 4;
   constructor(width, height, token) {
     super(width, height);
     this.token = token;
@@ -86,6 +87,30 @@ export default class PongGame extends NetworkScene {
       callback: async () => {
         const success = await this.cancelWaitQ();
         if (success) this.loadMenu();
+      },
+    }));
+    this.addGameObject(this.#createObject('light', {
+      position: {x: 0, y: 0, z: 20},
+      intensity: 500,
+    }));
+    this.#addTrackingMouseLight();
+    this.#addButtonEvents();
+  }
+
+  loadEndConfirm() {
+    this.state = PongGame.STATE_END;
+    this.loadDefaultScene();
+    this.addGameObject(this.#createObject('button', {
+      position: {x: 0, y: 0, z: 0},
+      color: 'green',
+      icon: 'close.png',
+      size: {width: 12, height: 12},
+      callback: async () => {
+        this.#netInfo({
+          "type": "info",
+          "cause": "end_game_confirm"
+        });
+        this.loadMenu();
       },
     }));
     this.addGameObject(this.#createObject('light', {
@@ -229,7 +254,7 @@ export default class PongGame extends NetworkScene {
 
     }
     if (data?.level === 'end game') {
-      this.loadMenu();
+      this.loadEndConfirm();
     }
   }
 


### PR DESCRIPTION
- #72

이전 pr의 내용을 보강하여, 오늘 정의한 [게임 진행 상황 통신 규칙](https://github.com/God-save-the-carrots/ft_transcendence/wiki/frontend-‐-game-api)에 따라 데이터를 전달할 수 있도록 수정했습니다.
게임의 시작부터 끝나는 순간까지의 이벤트를 다음과 같이 전달합니다.

start_game
---
토너먼트를 시작
```JSONC
{
  "type": "info",
  "cause": "start_game",
  "players": [
    {"intra_id": "yonshin", "photo_id": 0},
    {"intra_id": "yonshin", "photo_id": 0},
    {"intra_id": "yonshin", "photo_id": 0},
    {"intra_id": "yonshin", "photo_id": 0}
  ]
}
``````

start_session
---
토너먼트의 한 라운드의 한 세션을 시작
```JSONC
{
  "type": "info",
  "cause": "start_session",
  "tag": "round_2_1",
  "players": [
    {"intra_id": "yonshin", "photo_id": 0},
    {"intra_id": "yonshin", "photo_id": 0}
  ]
}
``````

end_session
---
토너먼트의 한 라운드의 한 세션이 끝남
```JSONC
{
  "type": "info",
  "cause": "end_session",
  "play_time": 18.451750993728638, // sec
  "tag": "round_2_1", // 2'nd round 1'st session
  "result": [
    {
      "intra_id": "yonshin",
      "photo_id": 0,
      "score": 3,
      "hit": 3
    },
    {
      "intra_id": "minjungk",
      "photo_id": 0,
      "score": 0,
      "hit": 3
    }
  ]
}
``````

end_game
---
토너먼트가 끝남
```JSONC
{
  "type": "info",
  "cause": "end_game"
}
```

end_game_confirm
---
토너먼트가 끝난 사실을 유저가 확인
```JSONC
{
  "type": "info",
  "cause": "end_game_confirm"
}
```
