### PR TITLE
Feat/gm loading screen

### DIFF
--- a/backend/game/NormalGame.py
+++ b/backend/game/NormalGame.py
@@ -12,9 +12,11 @@ class NormalGame(Rule):
         
     async def start(self):
         await self.step("start game", timer=1)
+        await self.step("start round", timer=1)
         self.game = self.game_constructor(self.players)
         self.game.onfinish = self.endsession
         result = await self.game.start()
+        await self.step("end round", timer=1)
         await self.step("end game", timer=1)
 
         losers = result.get("grade")[1:]

--- a/frontend/src/game/Scene.js
+++ b/frontend/src/game/Scene.js
@@ -133,6 +133,16 @@ export class Scene extends THREE.Scene {
     return gameObject;
   }
 
+  addGameObjectTo(gameObject, parent) {
+    if (gameObject == null) throw new Error('gameObject is null');
+    if (gameObject instanceof NetworkObject) {
+      this.networkObjects.set(gameObject.net.id, gameObject);
+    }
+    this.objects.set(gameObject.uuid, gameObject);
+    parent.add(gameObject);
+    return gameObject;
+  }
+
   getNetworkObject(id) {
     return this.networkObjects.get(id);
   }

--- a/frontend/src/game/Scene.js
+++ b/frontend/src/game/Scene.js
@@ -68,10 +68,13 @@ export class Scene extends THREE.Scene {
     // init render camera
     const aspect = this.width / this.height;
     this.camera = new THREE.PerspectiveCamera(75, aspect, 0.1, 1000);
-    this.camera.position.z = 42;
     this.renderer.setSize(this.width, this.height);
     this.renderer.shadowMap.enabled = true;
     this.composer.passes[0].camera = this.camera;
+    this.cameraHolder = new THREE.Object3D();
+    this.cameraHolder.position.z = 42;
+    this.cameraHolder.add(this.camera);
+    this.add(this.cameraHolder);
 
     // add background
     const background = new THREE.Mesh(

--- a/frontend/src/game/common/LoadingCircle.js
+++ b/frontend/src/game/common/LoadingCircle.js
@@ -8,9 +8,7 @@ export default class LoadingCircle extends GameObject {
       timer: 0,
       ...params,
     };
-    const geometry = new THREE.TorusGeometry( 15, 1, 3, 100 );
-    const material = new THREE.MeshPhongMaterial({color: params.color});
-    super(geometry, material);
+    super(new THREE.BufferGeometry(), new THREE.MeshBasicMaterial());
 
     this.updateCircle(0);
     this.timer = params.timer;
@@ -26,7 +24,7 @@ export default class LoadingCircle extends GameObject {
   updateCircle(percent = 0) { // 0 ~ 1
     if (this.circle) this.remove(this.circle);
     const angle = Math.PI * 2 * percent;
-    const geometry = new THREE.CircleGeometry(15, 100, Math.PI * 0.5, angle);
+    const geometry = new THREE.CircleGeometry(100, 100, Math.PI * 0.5, angle);
     const material = new THREE.MeshPhongMaterial({
       color: 0xffffff,
       transparent: true,

--- a/frontend/src/game/common/Shutter.js
+++ b/frontend/src/game/common/Shutter.js
@@ -1,0 +1,56 @@
+import * as THREE from '../../threejs/three.js';
+import {GameObject} from '../GameObject.js';
+
+export default class Shutter extends GameObject {
+  constructor(params) {
+    params = {
+      size: 10,
+      count: 6,
+      color: "gray",
+      position: {x: 0, y: 0, z: 0},
+      ...params,
+    };
+    super(new THREE.BufferGeometry(), new THREE.MeshBasicMaterial());
+    this.position.set(params.position.x, params.position.y, params.position.z);
+    this.size = params.size;
+    this.items = [];
+
+    const rectSize = 10000;
+    const count = params.count;
+    for (let i = 0; i < count; i++) {
+      const angle = ((Math.PI * 2) / count) * i;
+      const geometry = new THREE.PlaneGeometry(rectSize, rectSize);
+      const material = new THREE.MeshPhongMaterial({
+        color: params.color,
+        side: THREE.DoubleSide,
+      });
+      const rect = new THREE.Mesh(geometry, material);
+      rect.position.set(Math.sin(angle) * rectSize * 0.5, Math.cos(angle) * rectSize * 0.5, 0);
+      const axis = new THREE.Vector3(rect.position.x, rect.position.y, rect.position.z).normalize();
+      rect.rotateOnAxis(axis, Math.PI / count);
+      rect.rotateOnAxis(new THREE.Vector3(0, 0, 1), -angle);
+      const object = new THREE.Object3D();
+      object.add(rect)
+      const {x, y} = {x: Math.sin(angle), y: Math.cos(angle)};
+      object.normalPosition = {x, y};
+      object.position.set(x * this.size, y * this.size);
+      this.add(object);
+      this.items.push(object);
+    }
+    
+    window.test = this;
+  }
+
+  update() {
+    for (const item of this.items) {
+      const { normalPosition } = item;
+      item.position.x = item.position.x * 0.8 + normalPosition.x * this.size * 0.2;
+      item.position.y = item.position.y * 0.8 + normalPosition.y * this.size * 0.2;
+    }
+  }
+
+  setSize(size) {
+    this.size = size;
+    return this;
+  }
+}

--- a/frontend/src/game/pong/PongGame.js
+++ b/frontend/src/game/pong/PongGame.js
@@ -18,9 +18,9 @@ export default class PongGame extends NetworkScene {
   static STATE_PONG_TOURNAMENT = 3;
   static STATE_END = 4;
   static SHUTTER_SIZE_SMALL = 0;
-  static SHUTTER_SIZE_LARGE = 15;
-  static SHUTTER_SIZE_HUGE = 30;
-  static SHUTTER_HEIGHT = 15;
+  static SHUTTER_SIZE_LARGE = 10;
+  static SHUTTER_SIZE_HUGE = 15;
+  static SHUTTER_HEIGHT = -15;
   constructor(width, height, token) {
     super(width, height);
     this.token = token;
@@ -81,10 +81,10 @@ export default class PongGame extends NetworkScene {
     }));
     this.#addTrackingMouseLight();
     this.#addButtonEvents();
-    this.addGameObject(this.#createObject('shutter', {
+    this.addGameObjectTo(this.#createObject('shutter', {
       size: PongGame.SHUTTER_SIZE_LARGE,
       position: {x: 0, y: 0, z: PongGame.SHUTTER_HEIGHT},
-    }));
+    }), this.cameraHolder);
   }
 
   loadReady() {
@@ -106,10 +106,10 @@ export default class PongGame extends NetworkScene {
     }));
     this.#addTrackingMouseLight();
     this.#addButtonEvents();
-    this.addGameObject(this.#createObject('shutter', {
+    this.addGameObjectTo(this.#createObject('shutter', {
       size: PongGame.SHUTTER_SIZE_LARGE,
       position: {x: 0, y: 0, z: PongGame.SHUTTER_HEIGHT},
-    }));
+    }), this.cameraHolder);
   }
 
   loadEndConfirm() {
@@ -134,10 +134,10 @@ export default class PongGame extends NetworkScene {
     }));
     this.#addTrackingMouseLight();
     this.#addButtonEvents();
-    this.addGameObject(this.#createObject('shutter', {
+    this.addGameObjectTo(this.#createObject('shutter', {
       size: PongGame.SHUTTER_SIZE_SMALL,
       position: {x: 0, y: 0, z: PongGame.SHUTTER_HEIGHT},
-    }).setSize(PongGame.SHUTTER_SIZE_LARGE));
+    }).setSize(PongGame.SHUTTER_SIZE_LARGE), this.cameraHolder);
   }
 
   subscribeInfo(callback) {
@@ -176,7 +176,7 @@ export default class PongGame extends NetworkScene {
 
   #getMouseWorldPosition(screenX, screenY) {
     const rect = new THREE.Vector2();
-    this.camera.getViewSize(this.camera.position.z, rect);
+    this.camera.getViewSize(this.cameraHolder.position.z, rect);
     const ratio = {
       x: screenX / this.renderer.domElement.width,
       y: screenY / this.renderer.domElement.height,
@@ -240,17 +240,17 @@ export default class PongGame extends NetworkScene {
       const rawUnit = data.objects.filter((x) => x.id == unit.net.id)[0];
       const upside = (rawUnit.transform.rotation.y > 0 ? 1 : -1);
       const rad = Math.acos(rawUnit.transform.rotation.x) * upside;
-      const {camera} = this;
-      camera.position.set(unit.position.x, unit.position.y, camera.position.z);
-      camera.setRotationFromAxisAngle(zaxis, rad - Math.PI * 0.5);
-      camera.rotateX(Math.PI / 12);
+      const {cameraHolder} = this;
+      cameraHolder.position.set(unit.position.x, unit.position.y, cameraHolder.position.z);
+      cameraHolder.setRotationFromAxisAngle(zaxis, rad - Math.PI * 0.5);
+      cameraHolder.rotateX(Math.PI / 12);
     }
 
     this.shutter = this.#createObject('shutter', {
       size: PongGame.SHUTTER_SIZE_SMALL,
       position: {x: 0, y: 0, z: PongGame.SHUTTER_HEIGHT},
     }).setSize(PongGame.SHUTTER_SIZE_HUGE);
-    this.addGameObject(this.shutter);
+    this.addGameObjectTo(this.shutter, this.cameraHolder);
     this.addGameObject(this.#createObject('light', {
       position: {x: 0, y: 0, z: 42},
       intensity: 100,
@@ -280,7 +280,7 @@ export default class PongGame extends NetworkScene {
         size: PongGame.SHUTTER_SIZE_LARGE,
         position: {x: 0, y: 0, z: PongGame.SHUTTER_HEIGHT},
       }).setSize(PongGame.SHUTTER_SIZE_SMALL);
-      this.addGameObject(this.shutter);
+      this.addGameObjectTo(this.shutter, this.cameraHolder);
     }
     if (data?.level === 'start round') {
 

--- a/frontend/src/game/pong/PongGame.js
+++ b/frontend/src/game/pong/PongGame.js
@@ -9,6 +9,7 @@ import {zaxis} from '../preset.js';
 import Text from '../common/Text.js';
 import Icon from '../common/Icon.js';
 import LoadingCircle from '../common/LoadingCircle.js';
+import Shutter from '../common/Shutter.js';
 
 export default class PongGame extends NetworkScene {
   static STATE_MENU = 0;
@@ -29,8 +30,10 @@ export default class PongGame extends NetworkScene {
       'text': Text,
       'icon': Icon,
       'timer': LoadingCircle,
+      'loader': Shutter,
     };
     this.#initKeyEvent();
+    this.shutter = null;
     this.selectedButton = null;
     this.raycaster = new THREE.Raycaster();
     this.infoCallbacks = [];
@@ -74,6 +77,9 @@ export default class PongGame extends NetworkScene {
     }));
     this.#addTrackingMouseLight();
     this.#addButtonEvents();
+    this.addGameObject(this.#createObject('loader', {
+      position: {x: 0, y: 0, z: 15},
+    }));
   }
 
   loadReady() {
@@ -95,6 +101,9 @@ export default class PongGame extends NetworkScene {
     }));
     this.#addTrackingMouseLight();
     this.#addButtonEvents();
+    this.addGameObjectTo(this.#createObject('loader', {
+      position: {x: 0, y: 0, z: 15},
+    }), this.camera);
   }
 
   loadEndConfirm() {
@@ -119,6 +128,10 @@ export default class PongGame extends NetworkScene {
     }));
     this.#addTrackingMouseLight();
     this.#addButtonEvents();
+    this.addGameObjectTo(this.#createObject('loader', {
+      size: 0,
+      position: {x: 0, y: 0, z: 15},
+    }).setSize(10), this.camera);
   }
 
   subscribeInfo(callback) {
@@ -197,7 +210,7 @@ export default class PongGame extends NetworkScene {
   #netMatch(data) {
     const {status} = data;
     if (status === 'fail') this.loadReady();
-    if (status === 'success') this.loadDefaultScene(); // TODO:
+    if (status === 'success') this.loadDefaultScene();
   }
 
   #netInit(data) {
@@ -226,6 +239,13 @@ export default class PongGame extends NetworkScene {
       camera.setRotationFromAxisAngle(zaxis, rad - Math.PI * 0.5);
       camera.rotateX(Math.PI / 12);
     }
+
+    this.shutter = this.#createObject('loader', {
+      size: 0,
+      position: {x: 0, y: 0, z: 15},
+    }).setSize(20);
+    this.addGameObjectTo(this.shutter, this.camera);
+    this.camera.add(new PointLight());
   }
 
   #netUpdate(data) {
@@ -246,12 +266,18 @@ export default class PongGame extends NetworkScene {
   #netStep(data) {
     if (data?.level === 'start game') {
       this.loadDefaultScene();
+      this.#addTrackingMouseLight();
+      this.shutter = this.#createObject('loader', {
+        size: 10,
+        position: {x: 0, y: 0, z: 15},
+      }).setSize(0);
+      this.addGameObjectTo(this.shutter, this.camera);
     }
     if (data?.level === 'start round') {
 
     }
     if (data?.level === 'end round') {
-
+      this.shutter.setSize(0);
     }
     if (data?.level === 'end game') {
       this.loadEndConfirm();

--- a/frontend/src/game/pong/PongGame.js
+++ b/frontend/src/game/pong/PongGame.js
@@ -17,6 +17,10 @@ export default class PongGame extends NetworkScene {
   static STATE_PONG = 2;
   static STATE_PONG_TOURNAMENT = 3;
   static STATE_END = 4;
+  static SHUTTER_SIZE_SMALL = 0;
+  static SHUTTER_SIZE_LARGE = 15;
+  static SHUTTER_SIZE_HUGE = 30;
+  static SHUTTER_HEIGHT = 15;
   constructor(width, height, token) {
     super(width, height);
     this.token = token;
@@ -30,7 +34,7 @@ export default class PongGame extends NetworkScene {
       'text': Text,
       'icon': Icon,
       'timer': LoadingCircle,
-      'loader': Shutter,
+      'shutter': Shutter,
     };
     this.#initKeyEvent();
     this.shutter = null;
@@ -77,8 +81,9 @@ export default class PongGame extends NetworkScene {
     }));
     this.#addTrackingMouseLight();
     this.#addButtonEvents();
-    this.addGameObject(this.#createObject('loader', {
-      position: {x: 0, y: 0, z: 15},
+    this.addGameObject(this.#createObject('shutter', {
+      size: PongGame.SHUTTER_SIZE_LARGE,
+      position: {x: 0, y: 0, z: PongGame.SHUTTER_HEIGHT},
     }));
   }
 
@@ -101,9 +106,10 @@ export default class PongGame extends NetworkScene {
     }));
     this.#addTrackingMouseLight();
     this.#addButtonEvents();
-    this.addGameObjectTo(this.#createObject('loader', {
-      position: {x: 0, y: 0, z: 15},
-    }), this.camera);
+    this.addGameObject(this.#createObject('shutter', {
+      size: PongGame.SHUTTER_SIZE_LARGE,
+      position: {x: 0, y: 0, z: PongGame.SHUTTER_HEIGHT},
+    }));
   }
 
   loadEndConfirm() {
@@ -128,10 +134,10 @@ export default class PongGame extends NetworkScene {
     }));
     this.#addTrackingMouseLight();
     this.#addButtonEvents();
-    this.addGameObjectTo(this.#createObject('loader', {
-      size: 0,
-      position: {x: 0, y: 0, z: 15},
-    }).setSize(10), this.camera);
+    this.addGameObject(this.#createObject('shutter', {
+      size: PongGame.SHUTTER_SIZE_SMALL,
+      position: {x: 0, y: 0, z: PongGame.SHUTTER_HEIGHT},
+    }).setSize(PongGame.SHUTTER_SIZE_LARGE));
   }
 
   subscribeInfo(callback) {
@@ -240,12 +246,15 @@ export default class PongGame extends NetworkScene {
       camera.rotateX(Math.PI / 12);
     }
 
-    this.shutter = this.#createObject('loader', {
-      size: 0,
-      position: {x: 0, y: 0, z: 15},
-    }).setSize(20);
-    this.addGameObjectTo(this.shutter, this.camera);
-    this.camera.add(new PointLight());
+    this.shutter = this.#createObject('shutter', {
+      size: PongGame.SHUTTER_SIZE_SMALL,
+      position: {x: 0, y: 0, z: PongGame.SHUTTER_HEIGHT},
+    }).setSize(PongGame.SHUTTER_SIZE_HUGE);
+    this.addGameObject(this.shutter);
+    this.addGameObject(this.#createObject('light', {
+      position: {x: 0, y: 0, z: 42},
+      intensity: 100,
+    }));
   }
 
   #netUpdate(data) {
@@ -267,17 +276,17 @@ export default class PongGame extends NetworkScene {
     if (data?.level === 'start game') {
       this.loadDefaultScene();
       this.#addTrackingMouseLight();
-      this.shutter = this.#createObject('loader', {
-        size: 10,
-        position: {x: 0, y: 0, z: 15},
-      }).setSize(0);
-      this.addGameObjectTo(this.shutter, this.camera);
+      this.shutter = this.#createObject('shutter', {
+        size: PongGame.SHUTTER_SIZE_LARGE,
+        position: {x: 0, y: 0, z: PongGame.SHUTTER_HEIGHT},
+      }).setSize(PongGame.SHUTTER_SIZE_SMALL);
+      this.addGameObject(this.shutter);
     }
     if (data?.level === 'start round') {
 
     }
     if (data?.level === 'end round') {
-      this.shutter.setSize(0);
+      this.shutter.setSize(PongGame.SHUTTER_SIZE_SMALL);
     }
     if (data?.level === 'end game') {
       this.loadEndConfirm();


### PR DESCRIPTION
이 풀 리퀘스트는 천재적인 디자인 감각을 가진 사람이 아 몬가 필요한데 화면 전환 어떻게 하지 고민하다가 이것도 맘에 안들고 저것도 맘에 안들어 12시간 동안 삽질하다가 힘들게 힘들게 고안해 낸 셔터 방식의 화면 전환 매커니즘을 포함하고 주변 여백의 미를 허용하지 않으며 항상 주위에 남아 사용자의 마우스에 반응하여 빛을 발산하고 화면전환이 필요할때 알아서 슉 하고 닫히며 다시 슉 하고 열리는 것이 매우 예술적으로 보이며 성능 그딴거 신경쓰지 않고 어떻게든 셔터 장면 전환의 아름다움을 표현하고자 사람의 정신을 갈아 넣었는데 가령 셔터가 움직일 때 가속도를 사용하여 부드럽게 움직이고 셔터는 항상 카메라의 위치를 추적하여 정면으로 보이게 놓여지며 모든 평면들이 빛을 다른 방향으로 발산하고자 조금씩 밖을 향하도록 기울어져 있다는 것을 당근을 수호하는 신께서 보시더니 이런 정교하며 훌륭하게 만들어진 것은 무조건 승인하여야 한다고 하셨느니라.

<img width="487" alt="image" src="https://github.com/God-save-the-carrots/ft_transcendence/assets/25172705/b4858eaf-fcf1-43d7-a84e-af6fbeaf9c7e">

이 디자인에 트집 잡으면 나쁜 사람