### PR TITLE
Feat/fe error pages

### DIFF
--- a/frontend/public/assets/css/error.css
+++ b/frontend/public/assets/css/error.css
@@ -1,0 +1,1 @@
+@import "./home.css";

--- a/frontend/src/components/pages/ErrorPage.js
+++ b/frontend/src/components/pages/ErrorPage.js
@@ -22,11 +22,11 @@ export default class ErrorPage extends Component {
     <div class="content">
       <p> ${this._params.code} </p>
       <div class="img-wrap">
-        <img src="/public/assets/image/pacman.png" alt="" class="one">
-        <img src="/public/assets/image/ghost1.png" alt="" class="one">
-        <img src="/public/assets/image/ghost2.png" alt="" class="one">
-        <img src="/public/assets/image/ghost3.png" alt="" class="one">
-        <img src="/public/assets/image/ghost4.png" alt="" class="one">
+        <img src="/public/assets/image/pacman.png" alt="" class="two">
+        <img src="/public/assets/image/ghost1.png" alt="" class="two">
+        <img src="/public/assets/image/ghost2.png" alt="" class="two">
+        <img src="/public/assets/image/ghost3.png" alt="" class="two">
+        <img src="/public/assets/image/ghost4.png" alt="" class="two">
       </div>
       <p>
         <span>${this._params.msg}</span>

--- a/frontend/src/components/pages/ErrorPage.js
+++ b/frontend/src/components/pages/ErrorPage.js
@@ -3,16 +3,15 @@ import Component from '../../core/Component.js';
 export default class ErrorPage extends Component {
   _title;
   _params;
-  constructor(params = null) {
+  constructor(params = {}) {
     super(document.querySelector('#app'));
     this._title = 'Error';
-    if (params != null) this._params = params;
-    else {
-      this._params = {
-        code: '404',
-        msg: 'Not found',
-      };
+    this._params = {
+      code: '404',
+      msg: 'Not found',
+      ...params,      
     }
+  }
   }
   async template() {
     return `

--- a/frontend/src/components/pages/ErrorPage.js
+++ b/frontend/src/components/pages/ErrorPage.js
@@ -3,13 +3,37 @@ import Component from '../../core/Component.js';
 export default class ErrorPage extends Component {
   _title;
   _params;
-  constructor() {
+  constructor(params = null) {
     super(document.querySelector('#app'));
     this._title = 'Error';
+    if (params != null) this._params = params;
+    else {
+      this._params = {
+        code: '404',
+        msg: 'Not found',
+      };
+    }
   }
   async template() {
     return `
-      <h1> This is errorPage </h1>
+<link rel="stylesheet" type="text/css" href="/public/assets/css/error.css">
+  <div class="background">
+    <img class="map" src="../../public/assets/image/map.svg" alt="map">
+    <div class="content">
+      <p> ${this._params.code} </p>
+      <div class="img-wrap">
+        <img src="/public/assets/image/pacman.png" alt="" class="one">
+        <img src="/public/assets/image/ghost1.png" alt="" class="one">
+        <img src="/public/assets/image/ghost2.png" alt="" class="one">
+        <img src="/public/assets/image/ghost3.png" alt="" class="one">
+        <img src="/public/assets/image/ghost4.png" alt="" class="one">
+      </div>
+      <p>
+        <span>${this._params.msg}</span>
+      </p>
+    </div>
+  </div>
     `;
   }
+  async mounted() {}
 }

--- a/frontend/src/components/pages/Game.js
+++ b/frontend/src/components/pages/Game.js
@@ -47,7 +47,7 @@ export default class Game extends Component {
     `;
   }
   async mounted() {
-    console.log(this.state.sessionResults);
+    if (this.state.sessionResults == 'Error') return;
     const gameDiv = document.getElementById('game-body');
     if (this.state._alias !== null) {
       this.game.setAlias(this.state._alias);

--- a/frontend/src/components/pages/Rank.js
+++ b/frontend/src/components/pages/Rank.js
@@ -1,5 +1,6 @@
 import Component from '../../core/Component.js';
 import Router from '../../core/Router.js';
+import ErrorPage from './ErrorPage.js';
 
 export default class Rank extends Component {
   _title;

--- a/frontend/src/components/pages/Rank.js
+++ b/frontend/src/components/pages/Rank.js
@@ -21,10 +21,13 @@ export default class Rank extends Component {
     const rank_api = `http://localhost/api/game/pong/rank/`;
 
     const _current_page = this.state.current_page;
-    const data = await fetch(
-        rank_api + '?' + `page=${_current_page}&page_size=5`,
-    ).then((x) => x.json());
-
+    const res = await fetch(
+        rank_api + '?' + `page=${_current_page}&page_size=5`);
+    if (res.status != 200) {
+      new ErrorPage({code: res.status, msg: res.statusText});
+      return;
+    }
+    const data = await res.json();
     // TODO: block mine 로그인 연동하면 바꿔야 함
     let html = '';
     html += `
@@ -64,7 +67,7 @@ export default class Rank extends Component {
 }
 
 function createMyRanking() {
-  let list_HTML = `
+  const list_HTML = `
     <div class="title">RANKING</div>
     <li class="block mine">
       <span class="rank">1</span>

--- a/frontend/src/components/pages/User.js
+++ b/frontend/src/components/pages/User.js
@@ -10,6 +10,8 @@ export default class User extends Component {
   _title;
   _params;
   _myCss = '../../../public/assets/css/user.css';
+  _statistics = null;
+  _history = null;
   constructor(params = null) {
     super(document.querySelector('#app'));
     this._title = 'User';
@@ -47,7 +49,11 @@ export default class User extends Component {
     } else {
       new UserProfile(_test_app1, this._params.intra_id);
     }
-    new UserStatistics(_test_app2, this._params.intra_id);
+    if (this._statistics == null) {
+      this._statistics = new UserStatistics(_test_app2, this._params.intra_id);
+    } else {
+      this._statistics.render();
+    }
   }
 
   setEvent() {
@@ -59,8 +65,11 @@ export default class User extends Component {
         e.preventDefault();
         const href = e.target.getAttribute('href');
         const intra_id = this._params.intra_id;
-        if (href === 'history') new UserHistory(_test_app2, intra_id);
-        else new UserStatistics(_test_app2, intra_id);
+        if (href === 'history') {
+          if (this._history == null) {
+            this._history = new UserHistory(_test_app2, intra_id);
+          } else this._history.render();
+        } else this._statistics.render();
       }
     });
   }

--- a/frontend/src/components/pages/User.js
+++ b/frontend/src/components/pages/User.js
@@ -24,10 +24,10 @@ export default class User extends Component {
           <div class="stats_test"> </div>
           <div class="stats_link"> 
             <a href="statistics">
-              <p data-link>statistics</p></a>
+              <p userpage-link>statistics</p></a>
           </div>
           <div class="history_link"> 
-            <a href="history" data-link>history</a>
+            <a href="history" userpage-link>history</a>
           </div>
         </div>
         <div class="user-page" data-component="test-app2"></div>
@@ -51,11 +51,11 @@ export default class User extends Component {
   }
 
   setEvent() {
-    this.addEvent('click', '[data-link]', async (e) => {
+    this.addEvent('click', '[userpage-link]', async (e) => {
       const _test_app2 = this.$target.querySelector(
           '[data-component="test-app2"]',
       );
-      if (e.target.matches('[data-link]')) {
+      if (e.target.matches('[userpage-link]')) {
         e.preventDefault();
         const href = e.target.getAttribute('href');
         const intra_id = this._params.intra_id;

--- a/frontend/src/components/pages/UserHistory.js
+++ b/frontend/src/components/pages/UserHistory.js
@@ -62,7 +62,6 @@ function createHistoryPagination(current, last) {
   }
 
   for (let i = Number(current); i <= Number(current) + 2; i ++) {
-    console.log(i, Number(current) + 2);
     let index;
     if (i > last) index = '+';
     else index = i;
@@ -124,7 +123,6 @@ async function createHistoryContents(jsonData) {
     const data = await fetch(
         history_api,
     ).then((x) => x.json());
-    console.log(data.game[0]);
     const r2 = data.game[0];
     const r1_1 = data.game[1];
     const r1_2 = data.game[2];

--- a/frontend/src/components/pages/UserHistory.js
+++ b/frontend/src/components/pages/UserHistory.js
@@ -1,4 +1,5 @@
 import Component from '../../core/Component.js';
+import ErrorPage from './ErrorPage.js';
 
 export default class UserHistory extends Component {
   _title;
@@ -18,10 +19,13 @@ export default class UserHistory extends Component {
     const _current_page = this.state.current_page;
     let html = '';
     const history_api = `http://localhost/api/game/pong/score/${this._intra_id}`;
-    const data = await fetch(
-        history_api + '?' + `page=${_current_page}&page_size=1`,
-    ).then((x) => x.json());
-    // card
+    const res = await fetch(
+        history_api + '?' + `page=${_current_page}&page_size=1`);
+    if (res.status != 200) {
+      new ErrorPage({code: res.status, msg: res.statusText});
+      return;
+    }
+    const data = await res.json();
     const last_page_index = data.last_page_index;
     html += `
      <link rel="stylesheet" href="${this._my_css}" type="text/css" />
@@ -36,7 +40,7 @@ export default class UserHistory extends Component {
   async mounted() {}
 
   setEvent() {
-    this.addEvent('click', '.page-item', async (e) => {
+    this.addEvent('click', '.history-page-item', async (e) => {
       if (isNaN(e.target.dataset.page)) return;
       if (e.target.dataset.page != '+') {
         this.state.current_page = e.target.dataset.page;
@@ -55,7 +59,7 @@ function createHistoryPagination(current, last) {
     if (i > 0) index = i;
     else index = '+';
     list_HTML +=` 
-      <li class="page-item">
+      <li class="history-page-item">
         <a class="page-link" data-page=${index}>${index}</a>
       </li>
   `;
@@ -66,7 +70,7 @@ function createHistoryPagination(current, last) {
     if (i > last) index = '+';
     else index = i;
     list_HTML += `
-      <li class="page-item">
+      <li class="history-page-item">
         <a class="page-link" data-page=${index}>${index}</a>
       </li>
     `;
@@ -120,9 +124,12 @@ async function createHistoryContents(jsonData) {
             <div class="item">
 `;
     const history_api = `http://localhost/api/game/pong/matches/${match_id}`;
-    const data = await fetch(
-        history_api,
-    ).then((x) => x.json());
+    const res = await fetch(history_api);
+    if (res.status != 200) {
+      new ErrorPage({code: res.status, msg: res.statusText});
+      return;
+    }
+    const data = await res.json();
     const r2 = data.game[0];
     const r1_1 = data.game[1];
     const r1_2 = data.game[2];

--- a/frontend/src/components/pages/UserProfile.js
+++ b/frontend/src/components/pages/UserProfile.js
@@ -1,4 +1,5 @@
 import Component from '../../core/Component.js';
+import ErrorPage from './ErrorPage.js';
 
 export default class UserProfile extends Component {
   _title;
@@ -8,16 +9,14 @@ export default class UserProfile extends Component {
     this._intra_id = intra_id;
     this._title = 'UserProfile';
   }
-  async initState() {
-    return {
-      data: {},
-    };
-  }
   async template() {
     const profile_api = `http://localhost/api/game/pong/score/${this._intra_id}/profile`;
-    this.state.data = await fetch(profile_api,
-    ).then((x) => x.json());
-    const data = this.state.data;
+    const res = await fetch(profile_api);
+    if (res.status != 200) {
+      new ErrorPage({code: res.status, msg: res.statusText});
+      return;
+    }
+    const data = await res.json();
     const img = `/public/assets/profile/${data.user.photo_id}.png`;
     return `
 <div class="profile">

--- a/frontend/src/components/pages/UserProfileLogined.js
+++ b/frontend/src/components/pages/UserProfileLogined.js
@@ -1,4 +1,5 @@
 import Component from '../../core/Component.js';
+import ErrorPage from './ErrorPage.js';
 
 export default class UserProfile extends Component {
   _title;

--- a/frontend/src/components/pages/UserProfileLogined.js
+++ b/frontend/src/components/pages/UserProfileLogined.js
@@ -26,7 +26,7 @@ export default class UserProfile extends Component {
             return;
           }
           const change_api = `http://localhost/api/user/${this._intra_id}/`;
-          await fetch(change_api, {
+          const res = await fetch(change_api, {
             method: 'PATCH',
             headers: {
               'Content-Type': 'application/json',
@@ -34,6 +34,10 @@ export default class UserProfile extends Component {
             body: JSON.stringify({
               'photo_id': Number(photo_id)}),
           });
+          if (res.status != 200) {
+            new ErrorPage({code: res.status, msg: res.statusText});
+            return;
+          }
           this.state.photo_id = photo_id;
         });
   }
@@ -41,8 +45,12 @@ export default class UserProfile extends Component {
   async template() {
     if (this.state.photo_id > 8) return;
     const profile_api = `http://localhost/api/game/pong/score/${this._intra_id}/profile`;
-    const data = await fetch(profile_api,
-    ).then((x) => x.json());
+    const res = await fetch(profile_api);
+    if (res.status != 200) {
+      new ErrorPage({code: res.status, msg: res.statusText});
+      return;
+    }
+    const data = await res.json();
     const img = `/public/assets/profile/${data.user.photo_id}.png`;
     return `
 <link rel="stylesheet" href="${this._my_css}" type="text/css" />

--- a/frontend/src/components/pages/UserProfileLogined.js
+++ b/frontend/src/components/pages/UserProfileLogined.js
@@ -23,7 +23,6 @@ export default class UserProfile extends Component {
               .querySelector('input[name="avatar"]:checked').id;
           e.preventDefault();
           if (this.state.photo_id === photo_id) {
-            console.log('hello');
             return;
           }
           const change_api = `http://localhost/api/user/${this._intra_id}/`;

--- a/frontend/src/components/pages/UserStatistics.js
+++ b/frontend/src/components/pages/UserStatistics.js
@@ -97,7 +97,6 @@ export default class UserStatistics extends Component {
     const wp_api = `http://localhost/api/game/pong/score/${this._intra_id}/winning-percentage`;
     const wp_data = await fetch(wp_api,
     ).then((x) => x.json());
-    console.log(wp_data);
     html += `
 <div class="winning-percent">
   <p id="title"> Winning Percentage </p>

--- a/frontend/src/components/pages/UserStatistics.js
+++ b/frontend/src/components/pages/UserStatistics.js
@@ -1,4 +1,5 @@
 import Component from '../../core/Component.js';
+import ErrorPage from './ErrorPage.js';
 
 export default class UserStatistics extends Component {
   _title;

--- a/frontend/src/components/pages/UserStatistics.js
+++ b/frontend/src/components/pages/UserStatistics.js
@@ -11,9 +11,12 @@ export default class UserStatistics extends Component {
   }
   async template() {
     const playtime_api = `http://localhost/api/game/pong/score/${this._intra_id}/play-time`;
-    const playtime_data = await fetch(playtime_api,
-    ).then((x) => x.json());
-
+    const playtime_res = await fetch(playtime_api);
+    if (playtime_res.status != 200) {
+      new ErrorPage({code: playtime_res.status, msg: playtime_res.statusText});
+      return;
+    }
+    const playtime_data = await playtime_res.json();
     let html = `
       <link rel="stylesheet" href="${this._my_css}" type="text/css" />
       <div class="boxs">
@@ -32,8 +35,12 @@ export default class UserStatistics extends Component {
     `;
 
     const winning_api = `http://localhost/api/game/pong/score/${this._intra_id}/winning-rate`;
-    const winning_data = await fetch(winning_api,
-    ).then((x) => x.json());
+    const winning_res = await fetch(winning_api);
+    if (winning_res.status != 200) {
+      new ErrorPage({code: winning_res.status, msg: winning_res.statusText});
+      return;
+    }
+    const winning_data = await winning_res.json();
     const winning_ratio =
         calculateRatio(winning_data.winning_round, winning_data.losing_round);
 
@@ -60,8 +67,14 @@ export default class UserStatistics extends Component {
       </div>
     `;
     const goal_api = `http://localhost/api/game/pong/score/${this._intra_id}/goals-against-average`;
-    const goal_data = await fetch(goal_api,
-    ).then((x) => x.json());
+    const goal_res = await fetch(goal_api);
+    if (goal_res.status != 200) {
+      new ErrorPage({code: goal_res.status, msg: goal_res.statusText});
+      return;
+    }
+    const goal_data = await goal_res.json();
+
+
     const goal_ratio =
         calculateRatio(goal_data.user_score, goal_data.enemy_score);
     if (goal_ratio.value1Ratio == 0) {
@@ -95,8 +108,12 @@ export default class UserStatistics extends Component {
     `;
     }
     const wp_api = `http://localhost/api/game/pong/score/${this._intra_id}/winning-percentage`;
-    const wp_data = await fetch(wp_api,
-    ).then((x) => x.json());
+    const wp_res = await fetch(wp_api);
+    if (wp_res.status != 200) {
+      new ErrorPage({code: wp_res.status, msg: wp_res.statusText});
+      return;
+    }
+    const wp_data = await wp_res.json();
     html += `
 <div class="winning-percent">
   <p id="title"> Winning Percentage </p>

--- a/frontend/src/core/Router.js
+++ b/frontend/src/core/Router.js
@@ -1,4 +1,4 @@
-// import ErrorPage from '../components/pages/ErrorPage.js';
+import * as Utils from './Utils.js';
 
 class Router {
   #routes;
@@ -67,13 +67,17 @@ class Router {
         result: [location.pathname],
       };
     }
+    let params = null;
+    if (match.route.view !== 'ErrorPage') params = this.getParams(match);
+    if (match.route.view === 'User' &&
+      await Utils.isValidIntra(params.intra_id) === false) {
+      match.route.view = 'ErrorPage';
+      params.code = 404;
+      params.msg = 'User not found';
+    }
     this.#view = await import(`../components/pages/${match.route.view}.js`)
         .then(
             async ({default: Page}) => {
-              let params = null;
-              if (match.route.view !== 'ErrorPage') {
-                params = this.getParams(match);
-              }
               return new Page(params);
             },
         );

--- a/frontend/src/core/Router.js
+++ b/frontend/src/core/Router.js
@@ -1,11 +1,11 @@
-import ErrorPage from '../components/pages/ErrorPage.js';
+// import ErrorPage from '../components/pages/ErrorPage.js';
 
 class Router {
   #routes;
   #errorPage;
   #view;
   constructor() {
-    this.#errorPage = {path: '/404', view: ErrorPage};
+    this.#errorPage = {path: '/404', view: 'ErrorPage'};
     this.#routes = [
       {path: '/', view: 'Home'},
       {path: '/user/:intra_id', view: 'User'},
@@ -34,7 +34,6 @@ class Router {
   }
 
   async navigateTo(url, title = null) {
-    console.log(url, location.href);
     if (url != undefined && url !== location.href) {
       history.pushState({}, title, url);
     } else {
@@ -71,7 +70,11 @@ class Router {
     this.#view = await import(`../components/pages/${match.route.view}.js`)
         .then(
             async ({default: Page}) => {
-              return new Page(this.getParams(match));
+              let params = null;
+              if (match.route.view !== 'ErrorPage') {
+                params = this.getParams(match);
+              }
+              return new Page(params);
             },
         );
     return this.#view;

--- a/frontend/src/core/Utils.js
+++ b/frontend/src/core/Utils.js
@@ -1,0 +1,13 @@
+export async function isValidIntra(intra) {
+  const apiUrl = `http://localhost/api/user/${intra}/`;
+  try {
+    const response = await fetch(apiUrl);
+    if (response.ok) {
+      return true;
+    } else {
+      return false;
+    }
+  } catch (error) {
+    return false;
+  }
+}


### PR DESCRIPTION
# 에러 페이지 처리 
- errorpage 만듬 ( params 에 code 와 status 를 받을 수 있게함, default 는 404)
- 라우터 : 존재하지 않는 url, user/instra_id 가 존재 하지 않는 경우 에러 페이지 내보냄 
- api 를 받거나 보내는 경우 : response 의 status 를 확인한 후, 200 이 아니면 그 페이지에서 벗어나서 에러 페이지 랜더링하게 함 

#기타 처리 
- 랭킹 페이지와 유저 페이지가 같은 link 를 쓰는 것을 수정 함 (user page 와 history page 의 event ) 
- console.log 삭제
- 
